### PR TITLE
Add chakra capability

### DIFF
--- a/src/main/java/net/sincere/jutsucraft/Jutsucraft.java
+++ b/src/main/java/net/sincere/jutsucraft/Jutsucraft.java
@@ -23,6 +23,8 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
+import net.sincere.jutsucraft.chakra.ChakraProvider;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -102,6 +104,14 @@ public class Jutsucraft {
     public void onServerStarting(ServerStartingEvent event) {
         // Do something when the server starts
         LOGGER.info("HELLO from server starting");
+    }
+
+    @Mod.EventBusSubscriber(modid = MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
+    public static class ModEvents {
+        @SubscribeEvent
+        public static void registerCapabilities(RegisterCapabilitiesEvent event) {
+            ChakraProvider.register(event);
+        }
     }
 
     // You can use EventBusSubscriber to automatically register all static methods in the class annotated with @SubscribeEvent

--- a/src/main/java/net/sincere/jutsucraft/chakra/Chakra.java
+++ b/src/main/java/net/sincere/jutsucraft/chakra/Chakra.java
@@ -1,0 +1,41 @@
+package net.sincere.jutsucraft.chakra;
+
+import net.minecraft.nbt.CompoundTag;
+
+public class Chakra implements IChakra {
+    private int chakra = 0;
+    private int maxChakra = 100;
+
+    @Override
+    public int getChakra() {
+        return chakra;
+    }
+
+    @Override
+    public int getMaxChakra() {
+        return maxChakra;
+    }
+
+    @Override
+    public void setChakra(int value) {
+        this.chakra = Math.max(0, Math.min(value, maxChakra));
+    }
+
+    @Override
+    public void setMaxChakra(int value) {
+        this.maxChakra = Math.max(0, value);
+        if (chakra > maxChakra) {
+            chakra = maxChakra;
+        }
+    }
+
+    public void saveNBTData(CompoundTag nbt) {
+        nbt.putInt("chakra", chakra);
+        nbt.putInt("maxChakra", maxChakra);
+    }
+
+    public void loadNBTData(CompoundTag nbt) {
+        this.chakra = nbt.getInt("chakra");
+        this.maxChakra = nbt.getInt("maxChakra");
+    }
+}

--- a/src/main/java/net/sincere/jutsucraft/chakra/ChakraEvents.java
+++ b/src/main/java/net/sincere/jutsucraft/chakra/ChakraEvents.java
@@ -1,0 +1,40 @@
+package net.sincere.jutsucraft.chakra;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class ChakraEvents {
+    private static final String CHAKRA_ID = "chakra";
+
+    @SubscribeEvent
+    public static void attachCapabilities(AttachCapabilitiesEvent<Entity> event) {
+        if (event.getObject() instanceof Player) {
+            event.addCapability(new net.minecraft.resources.ResourceLocation("jutsucraft", CHAKRA_ID), new ChakraProvider());
+        }
+    }
+
+    @SubscribeEvent
+    public static void playerClone(PlayerEvent.Clone event) {
+        event.getOriginal().getCapability(ChakraProvider.CHAKRA_CAPABILITY).ifPresent(oldStore -> {
+            event.getEntity().getCapability(ChakraProvider.CHAKRA_CAPABILITY).ifPresent(newStore -> {
+                newStore.setMaxChakra(oldStore.getMaxChakra());
+                newStore.setChakra(oldStore.getChakra());
+            });
+        });
+    }
+
+    @SubscribeEvent
+    public static void playerTick(TickEvent.PlayerTickEvent event) {
+        if (!event.player.level().isClientSide && event.phase == TickEvent.Phase.END) {
+            event.player.getCapability(ChakraProvider.CHAKRA_CAPABILITY).ifPresent(chakra -> {
+                chakra.addChakra(1); // simple regen
+            });
+        }
+    }
+}

--- a/src/main/java/net/sincere/jutsucraft/chakra/ChakraProvider.java
+++ b/src/main/java/net/sincere/jutsucraft/chakra/ChakraProvider.java
@@ -1,0 +1,43 @@
+package net.sincere.jutsucraft.chakra;
+
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityToken;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.common.util.INBTSerializable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class ChakraProvider implements ICapabilityProvider, INBTSerializable<CompoundTag> {
+    public static Capability<IChakra> CHAKRA_CAPABILITY = CapabilityManager.get(new CapabilityToken<>() {});
+
+    private final Chakra chakra = new Chakra();
+    private final LazyOptional<IChakra> optional = LazyOptional.of(() -> chakra);
+
+    public static void register(RegisterCapabilitiesEvent event) {
+        event.register(IChakra.class);
+    }
+
+    @Nonnull
+    @Override
+    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side) {
+        return cap == CHAKRA_CAPABILITY ? optional.cast() : LazyOptional.empty();
+    }
+
+    @Override
+    public CompoundTag serializeNBT() {
+        CompoundTag nbt = new CompoundTag();
+        chakra.saveNBTData(nbt);
+        return nbt;
+    }
+
+    @Override
+    public void deserializeNBT(CompoundTag nbt) {
+        chakra.loadNBTData(nbt);
+    }
+}

--- a/src/main/java/net/sincere/jutsucraft/chakra/IChakra.java
+++ b/src/main/java/net/sincere/jutsucraft/chakra/IChakra.java
@@ -1,0 +1,21 @@
+package net.sincere.jutsucraft.chakra;
+
+public interface IChakra {
+    int getChakra();
+    int getMaxChakra();
+
+    void setChakra(int value);
+    void setMaxChakra(int value);
+
+    default void addChakra(int amount) {
+        setChakra(Math.min(getChakra() + amount, getMaxChakra()));
+    }
+
+    default boolean consumeChakra(int amount) {
+        if (getChakra() >= amount) {
+            setChakra(getChakra() - amount);
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- implement basic chakra capability
- register capability in mod events
- persist chakra data between deaths and tick regen

## Testing
- `./gradlew --version`
- `./gradlew classes` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_684046625f008330919dc16f7e101fbd